### PR TITLE
Add modular Excel sync workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import FileUploader from './components/FileUploader';
+import Uploader from './components/Uploader';
 import Summary from './components/Summary';
-import { parseExcelFile } from './utils/excelParser';
-import { processTasks } from './utils/dataProcessor';
+import { validateAndParse } from './utils/validator';
+import { processTasks } from './utils/processor';
 import { ProcessSummary, Task } from './types/task';
 import { AlertCircle } from 'lucide-react';
 
@@ -19,7 +19,7 @@ function App() {
     setError(null);
 
     try {
-      const tasks: Task[] = await parseExcelFile(selectedFile);
+      const tasks: Task[] = await validateAndParse(selectedFile);
 
       if (tasks.length === 0) {
         setError('The selected file is empty or the "Tareas" sheet contains no data rows.');
@@ -58,7 +58,7 @@ function App() {
           </div>
         )}
 
-        <FileUploader onFileSelect={handleFileSelect} disabled={processing} />
+        <Uploader onFileSelect={handleFileSelect} disabled={processing} />
 
         <Summary summary={summary} processing={processing} />
 

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { UploadCloud } from 'lucide-react';
 
-interface FileUploaderProps {
+interface UploaderProps {
   onFileSelect: (file: File) => void;
   disabled: boolean;
 }
 
-const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelect, disabled }) => {
+const Uploader: React.FC<UploaderProps> = ({ onFileSelect, disabled }) => {
   const [fileName, setFileName] = useState<string | null>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,4 +40,4 @@ const FileUploader: React.FC<FileUploaderProps> = ({ onFileSelect, disabled }) =
   );
 };
 
-export default FileUploader;
+export default Uploader;

--- a/src/utils/processor.ts
+++ b/src/utils/processor.ts
@@ -1,6 +1,6 @@
 import { supabase } from '../lib/supabaseClient';
 import { Task, ProcessedTask, ProcessSummary } from '../types/task';
-import { excelDateToISOString } from './excelParser';
+import { excelDateToISOString } from './validator';
 
 export const processTasks = async (tasks: Task[], onProgress: (summary: ProcessSummary) => void): Promise<ProcessSummary> => {
   let summary: ProcessSummary = {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -14,7 +14,7 @@ const REQUIRED_COLUMNS = [
   'Con retraso',
 ];
 
-export const parseExcelFile = (file: File): Promise<Task[]> => {
+export const validateAndParse = (file: File): Promise<Task[]> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'dist',
+    target: 'es2018',
+    minify: 'esbuild',
+    sourcemap: false,
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
-  server: {
-    allowedHosts: [
-      '.csb.app'           
-    ]
-  }
-})
+});


### PR DESCRIPTION
## Summary
- rename uploader component and split utils into `validator` and `processor`
- update imports in `App`
- tweak Vite config for Vercel deployments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5fdd870832b9180eb6297fa5582